### PR TITLE
Documentation/#7 extend readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,26 @@
 
 The Go service that helps you refactor and monitor the refactoring of critical REST APIs.
 
-## Develop
+## Get it go-ing
+
+To use the Web Scientist download docker and run the following command in a CLI of your choice
+
+```
+$ docker run docker.sprinteins.com/users/trusz/web-scientist:v1.0.0
+```
+
+## How to participate in development
+
+Clone the repository to the directory.
+
+```
+$ git clone https://github.com/sprinteins/web-scientist.git 
+```
+
+Enter into the downloaded directory and docker-compose the service up!
 
 ```sh
-docker-compose up web-scientist-dev
+$ cd web-scientist
+
+$ docker-compose up web-scientist-dev
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Go service that helps you refactor and monitor the refactoring of critical R
 
 ## Get it go-ing
 
-To use the Web Scientist download docker and run the following command in a CLI of your choice
+To use the Web Scientist download docker and run the following command.
 
 ```
 $ docker run docker.sprinteins.com/users/trusz/web-scientist:v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Web Scientist
 
+The Go service that helps you refactor and monitor the refactoring of critical REST APIs.
+
 ## Develop
 
 ```sh


### PR DESCRIPTION
Bei dem README Inhalt sind 2 Sachen nicht vollständig bzw. im jetzigen Zeitpunkt nicht existieren.

1. Bei der Bedienung
- Gibt es zurzeit einen Richtigen weg um es "produktiv" ein zusetzten? Es gibt bisher noch keine MAKEFILE für prod und das Image ist noch nicht auf hub.docker geladen.

2. Beim Development
- Es sieht nicht so aus als ob der Container auf etwas hört. Wird mit dem "realize start" Befehl auch der Server gestartet / die main.go in der "src/"  gestartet oder nur die Tests?

Closes #7 