### PR TITLE
Feature/#4 dont block reference call

### DIFF
--- a/src/server/difference/difference.go
+++ b/src/server/difference/difference.go
@@ -11,7 +11,7 @@ import (
 type Difference struct {
 	Status    map[string]string
 	Proto     map[string]string
-	Header    map[string]http.Response.Header
+	Header    map[string]header
 	Body      map[string]string
 	Identical equal
 }
@@ -23,14 +23,16 @@ type equal struct {
 	Header 	bool
 }
 
+type header map[string][]string
+
 // New _
 func New() *Difference {
 	return &Difference{
 		make(map[string]string),
 		make(map[string]string),
-		make(map[string]map[string][]string),
+		make(map[string]header),
 		make(map[string]string),
-		make(map[string]bool),
+		equal{false, false, false, false},
 	}
 }
 
@@ -54,7 +56,6 @@ func (JL *Difference) CompareResponses(refResp *http.Response, expResp *http.Res
 
 // BodyToString _
 func BodyToString(body io.ReadCloser) (string, error) {
-	defer body.Close()
 	payload, err := ioutil.ReadAll(body)
 	if err != nil {
 		return "", err
@@ -113,7 +114,7 @@ func (JL *Difference) compareHeader(headerA map[string][]string, headerB map[str
 
 	JL.Identical.Header = isIdentical
 
-	m := make(map[string]map[string][]string)
+	m := make(map[string]header)
 	m["RefResponse"] = headerA
 	m["ExpResponse"] = headerB
 	JL.Header = m

--- a/src/server/difference/difference.go
+++ b/src/server/difference/difference.go
@@ -1,4 +1,4 @@
-package jlog
+package difference
 
 import (
 	"encoding/json"
@@ -7,18 +7,25 @@ import (
 	"net/http"
 )
 
-// JLog _
-type JLog struct {
+// Difference _
+type Difference struct {
 	Status    map[string]string
 	Proto     map[string]string
-	Header    map[string]map[string][]string
+	Header    map[string]http.Response.Header
 	Body      map[string]string
-	Identical map[string]bool
+	Identical equal
+}
+
+type equal struct {
+	Status 	bool
+	Proto 	bool
+	Body 	bool
+	Header 	bool
 }
 
 // New _
-func New() *JLog {
-	return &JLog{
+func New() *Difference {
+	return &Difference{
 		make(map[string]string),
 		make(map[string]string),
 		make(map[string]map[string][]string),
@@ -28,12 +35,12 @@ func New() *JLog {
 }
 
 // CompareResponses _
-func (JL *JLog) CompareResponses(refResp *http.Response, expResp *http.Response) ([]byte, error) {
+func (JL *Difference) CompareResponses(refResp *http.Response, expResp *http.Response) ([]byte, error) {
 
-	JL.CompareStatus(refResp.Status, expResp.Status)
-	JL.CompareProto(refResp.Proto, expResp.Proto)
-	JL.CompareHeader(refResp.Header, expResp.Header)
-	err := JL.CompareBody(refResp.Body, expResp.Body)
+	JL.compareStatus(refResp.Status, expResp.Status)
+	JL.compareProto(refResp.Proto, expResp.Proto)
+	JL.compareHeader(refResp.Header, expResp.Header)
+	err := JL.compareBody(refResp.Body, expResp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -57,12 +64,12 @@ func BodyToString(body io.ReadCloser) (string, error) {
 }
 
 // CompareStatus _
-func (JL *JLog) CompareStatus(statusA string, statusB string) {
+func (JL *Difference) compareStatus(statusA string, statusB string) {
 
 	if statusA == statusB {
-		JL.Identical["Status"] = true
+		JL.Identical.Status = true
 	} else {
-		JL.Identical["Status"] = false
+		JL.Identical.Status = false
 	}
 
 	m := make(map[string]string)
@@ -72,11 +79,11 @@ func (JL *JLog) CompareStatus(statusA string, statusB string) {
 }
 
 // CompareProto _
-func (JL *JLog) CompareProto(protoA string, protoB string) {
+func (JL *Difference) compareProto(protoA string, protoB string) {
 	if protoA == protoB {
-		JL.Identical["Proto"] = true
+		JL.Identical.Proto = true
 	} else {
-		JL.Identical["Proto"] = false
+		JL.Identical.Proto = false
 	}
 
 	m := make(map[string]string)
@@ -86,7 +93,7 @@ func (JL *JLog) CompareProto(protoA string, protoB string) {
 }
 
 // CompareHeader _
-func (JL *JLog) CompareHeader(headerA map[string][]string, headerB map[string][]string) {
+func (JL *Difference) compareHeader(headerA map[string][]string, headerB map[string][]string) {
 
 	isIdentical := true
 
@@ -104,7 +111,7 @@ func (JL *JLog) CompareHeader(headerA map[string][]string, headerB map[string][]
 		}
 	}
 
-	JL.Identical["Header"] = isIdentical
+	JL.Identical.Header = isIdentical
 
 	m := make(map[string]map[string][]string)
 	m["RefResponse"] = headerA
@@ -113,7 +120,7 @@ func (JL *JLog) CompareHeader(headerA map[string][]string, headerB map[string][]
 }
 
 // CompareBody _
-func (JL *JLog) CompareBody(bodyA io.ReadCloser, bodyB io.ReadCloser) error {
+func (JL *Difference) compareBody(bodyA io.ReadCloser, bodyB io.ReadCloser) error {
 	bodyAStr, err := BodyToString(bodyA)
 	if err != nil {
 		return err
@@ -125,9 +132,9 @@ func (JL *JLog) CompareBody(bodyA io.ReadCloser, bodyB io.ReadCloser) error {
 	}
 
 	if bodyAStr == bodyBStr {
-		JL.Identical["Body"] = true
+		JL.Identical.Body = true
 	} else {
-		JL.Identical["Body"] = false
+		JL.Identical.Body = false
 	}
 
 	m := make(map[string]string)

--- a/src/server/jlog/jlog.go
+++ b/src/server/jlog/jlog.go
@@ -1,0 +1,117 @@
+package jlog
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+// JLog _
+type JLog struct {
+	Status    map[string]string
+	Proto     map[string]string
+	Header    map[string]map[string][]string
+	Body      map[string]string
+	Identical map[string]bool
+}
+
+// New _
+func CompareResponses(refResp *http.Response, expResp *http.Response) (string, error) {
+
+	JL := new(JLog)
+
+	JL.CompareStatus(refResp.Status, expResp.Status)
+	JL.CompareProto(refResp.Proto, expResp.Proto)
+	JL.CompareHeader(refResp.Header, expResp.Header)
+	err := JL.CompareBody(refResp.Body, expResp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	str, err := json.Marshal(JL)
+	if err != nil {
+		return "", err
+	}
+	return string(str), nil
+}
+
+// BodyToString _
+func BodyToString(body io.ReadCloser) (string, error) {
+	defer body.Close()
+	payload, err := ioutil.ReadAll(body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(payload), nil
+}
+
+// CompareStatus _
+func (JL JLog) CompareStatus(statusA string, statusB string) {
+
+	if statusA == statusB {
+		JL.Identical["Status"] = true
+	} else {
+		JL.Identical["Status"] = false
+	}
+
+	m := make(map[string]string)
+	m["RefResponse"] = statusA
+	m["ExpResponse"] = statusB
+	JL.Status = m
+}
+
+// CompareProto _
+func (JL JLog) CompareProto(protoA string, protoB string) {
+	if protoA == protoB {
+		JL.Identical["Proto"] = false
+	} else {
+		JL.Identical["Proto"] = false
+	}
+
+	m := make(map[string]string)
+	m["RefResponse"] = protoA
+	m["ExpResponse"] = protoB
+	JL.Proto = m
+}
+
+// CompareHeader _
+func (JL JLog) CompareHeader(headerA map[string][]string, headerB map[string][]string) {
+
+	isIdentical := true
+
+	for key, value := range headerA {
+		for i, str := range value {
+			if str != headerB[key][i] {
+				isIdentical = false
+				break
+			}
+		}
+	}
+
+	JL.Identical["Header"] = isIdentical
+
+	m := make(map[string]map[string][]string)
+	m["RefResponse"] = headerA
+	m["ExpResponse"] = headerB
+	JL.Header = m
+}
+
+// CompareBody _
+func (JL JLog) CompareBody(bodyA io.ReadCloser, bodyB io.ReadCloser) error {
+	bodyAStr, err := BodyToString(bodyA)
+	if err != nil {
+		return err
+	}
+	bodyBStr, err := BodyToString(bodyB)
+	if err != nil {
+		return err
+	}
+
+	m := make(map[string]string)
+	m["RefResponse"] = bodyAStr
+	m["ExpResponse"] = bodyBStr
+	JL.Body = m
+	return nil
+}

--- a/src/server/jlog/jlog.go
+++ b/src/server/jlog/jlog.go
@@ -58,13 +58,13 @@ func BodyToString(body io.ReadCloser) (string, error) {
 
 // CompareStatus _
 func (JL *JLog) CompareStatus(statusA string, statusB string) {
-	
+
 	if statusA == statusB {
 		JL.Identical["Status"] = true
 	} else {
 		JL.Identical["Status"] = false
 	}
-		
+
 	m := make(map[string]string)
 	m["RefResponse"] = statusA
 	m["ExpResponse"] = statusB
@@ -92,7 +92,12 @@ func (JL *JLog) CompareHeader(headerA map[string][]string, headerB map[string][]
 
 	for key, value := range headerA {
 		for i, str := range value {
-			if str != headerB[key][i] {
+			if headerB[key] != nil {
+				if str != headerB[key][i] {
+					isIdentical = false
+					break
+				}
+			} else {
 				isIdentical = false
 				break
 			}

--- a/src/server/jlog/jlog.go
+++ b/src/server/jlog/jlog.go
@@ -47,7 +47,6 @@ func (JL *JLog) CompareResponses(refResp *http.Response, expResp *http.Response)
 
 // BodyToString _
 func BodyToString(body io.ReadCloser) (string, error) {
-	defer body.Close()
 	payload, err := ioutil.ReadAll(body)
 	if err != nil {
 		return "", err

--- a/src/server/jlog/jlog.go
+++ b/src/server/jlog/jlog.go
@@ -17,9 +17,18 @@ type JLog struct {
 }
 
 // New _
-func CompareResponses(refResp *http.Response, expResp *http.Response) (string, error) {
+func New() *JLog {
+	return &JLog{
+		make(map[string]string),
+		make(map[string]string),
+		make(map[string]map[string][]string),
+		make(map[string]string),
+		make(map[string]bool),
+	}
+}
 
-	JL := new(JLog)
+// CompareResponses _
+func (JL *JLog) CompareResponses(refResp *http.Response, expResp *http.Response) (string, error) {
 
 	JL.CompareStatus(refResp.Status, expResp.Status)
 	JL.CompareProto(refResp.Proto, expResp.Proto)
@@ -48,14 +57,14 @@ func BodyToString(body io.ReadCloser) (string, error) {
 }
 
 // CompareStatus _
-func (JL JLog) CompareStatus(statusA string, statusB string) {
-
+func (JL *JLog) CompareStatus(statusA string, statusB string) {
+	
 	if statusA == statusB {
 		JL.Identical["Status"] = true
 	} else {
 		JL.Identical["Status"] = false
 	}
-
+		
 	m := make(map[string]string)
 	m["RefResponse"] = statusA
 	m["ExpResponse"] = statusB
@@ -63,7 +72,7 @@ func (JL JLog) CompareStatus(statusA string, statusB string) {
 }
 
 // CompareProto _
-func (JL JLog) CompareProto(protoA string, protoB string) {
+func (JL *JLog) CompareProto(protoA string, protoB string) {
 	if protoA == protoB {
 		JL.Identical["Proto"] = false
 	} else {
@@ -77,7 +86,7 @@ func (JL JLog) CompareProto(protoA string, protoB string) {
 }
 
 // CompareHeader _
-func (JL JLog) CompareHeader(headerA map[string][]string, headerB map[string][]string) {
+func (JL *JLog) CompareHeader(headerA map[string][]string, headerB map[string][]string) {
 
 	isIdentical := true
 
@@ -99,19 +108,27 @@ func (JL JLog) CompareHeader(headerA map[string][]string, headerB map[string][]s
 }
 
 // CompareBody _
-func (JL JLog) CompareBody(bodyA io.ReadCloser, bodyB io.ReadCloser) error {
+func (JL *JLog) CompareBody(bodyA io.ReadCloser, bodyB io.ReadCloser) error {
 	bodyAStr, err := BodyToString(bodyA)
 	if err != nil {
 		return err
 	}
+
 	bodyBStr, err := BodyToString(bodyB)
 	if err != nil {
 		return err
+	}
+
+	if bodyAStr == bodyBStr {
+		JL.Identical["Body"] = false
+	} else {
+		JL.Identical["Body"] = false
 	}
 
 	m := make(map[string]string)
 	m["RefResponse"] = bodyAStr
 	m["ExpResponse"] = bodyBStr
 	JL.Body = m
+
 	return nil
 }

--- a/src/server/jlog/jlog.go
+++ b/src/server/jlog/jlog.go
@@ -28,21 +28,21 @@ func New() *JLog {
 }
 
 // CompareResponses _
-func (JL *JLog) CompareResponses(refResp *http.Response, expResp *http.Response) (string, error) {
+func (JL *JLog) CompareResponses(refResp *http.Response, expResp *http.Response) ([]byte, error) {
 
 	JL.CompareStatus(refResp.Status, expResp.Status)
 	JL.CompareProto(refResp.Proto, expResp.Proto)
 	JL.CompareHeader(refResp.Header, expResp.Header)
 	err := JL.CompareBody(refResp.Body, expResp.Body)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	str, err := json.Marshal(JL)
+	str, err := json.MarshalIndent(JL, "", " ")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return string(str), nil
+	return str, nil
 }
 
 // BodyToString _
@@ -74,7 +74,7 @@ func (JL *JLog) CompareStatus(statusA string, statusB string) {
 // CompareProto _
 func (JL *JLog) CompareProto(protoA string, protoB string) {
 	if protoA == protoB {
-		JL.Identical["Proto"] = false
+		JL.Identical["Proto"] = true
 	} else {
 		JL.Identical["Proto"] = false
 	}
@@ -120,7 +120,7 @@ func (JL *JLog) CompareBody(bodyA io.ReadCloser, bodyB io.ReadCloser) error {
 	}
 
 	if bodyAStr == bodyBStr {
-		JL.Identical["Body"] = false
+		JL.Identical["Body"] = true
 	} else {
 		JL.Identical["Body"] = false
 	}

--- a/src/server/main.go
+++ b/src/server/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sync"
 	"github.com/sprinteins/web-scientist/server/jlog"
 )
 
@@ -71,31 +72,73 @@ func (s *Server) SetExperiment(target string) {
 func (s *Server) handle(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("X-WebScientist", "WebScientist")
 
+	wg := sync.WaitGroup{}
+
+	refRespCh := make(chan *http.Response)
+	defer close(refRespCh)
+	expRespCh := make(chan *http.Response)
+	defer close(expRespCh)
+	
+	doneCh := make(chan struct{})
+
 	var reqRef, reqExp = duplicate(req)
 
-	respA, err := sendFurther(reqRef, s.reference)
-	if err != nil {
-		log.Fatal(err)
-	}
+	go func() {
+		err := sendFurther(refRespCh, reqRef, s.reference)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+	
+	go func() {
+		err := sendFurther(expRespCh, reqExp, s.experiment)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+	
+	refResponse := &http.Response{}
 
-	respB, err := sendFurther(reqExp, s.experiment)
-	if err != nil {
-		log.Fatal(err)
-	}
+	go func() {
+		refResponse = <-refRespCh
+		refBodyStr, err := jlog.BodyToString(refResponse.Body)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Fprintln(w, refBodyStr)
+		doneCh <- struct{}{}
+	}()
 
-	JL := jlog.New()
-	out, _ := JL.CompareResponses(respA, respB)
-	ioutil.WriteFile("log.json", out, 0755)
+	wg.Add(1)
+	go func() {
+		<-doneCh
+		expResponse := <-expRespCh
+		
+		JL := jlog.New()
 
+		out, err := JL.CompareResponses(refResponse, expResponse)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer expResponse.Body.Close()
+		defer refResponse.Body.Close()
+		
+		ioutil.WriteFile("log.json", out, 0755)
+		
+		wg.Done()
+	}()
+
+	wg.Wait()
 }
 
-func sendFurther(req *http.Request, url *url.URL) (*http.Response, error) {
+func sendFurther(respChannel chan<- *http.Response, req *http.Request, url *url.URL) error {
 	req.URL = url
 	resp, err := http.DefaultTransport.RoundTrip(req)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return resp, nil
+	respChannel <- resp
+	return nil
 }
 
 func duplicate(request *http.Request) (request1 *http.Request, request2 *http.Request) {

--- a/src/server/main.go
+++ b/src/server/main.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"github.com/sprinteins/web-scientist/server/jlog"
+	"github.com/sprinteins/web-scientist/server/difference"
 )
 
 // Server _
@@ -83,8 +83,8 @@ func (s *Server) handle(w http.ResponseWriter, req *http.Request) {
 		log.Fatal(err)
 	}
 
-	JL := jlog.New()
-	out, _ := JL.CompareResponses(respA, respB)
+	diff := difference.New()
+	out, _ := diff.CompareResponses(respA, respB)
 	ioutil.WriteFile("log.json", out, 0755)
 
 }

--- a/src/server/main.go
+++ b/src/server/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"github.com/sprinteins/web-scientist/server/jlog"
 )
 
 // Server _
@@ -108,16 +109,6 @@ func sendFurther(req *http.Request, url *url.URL) (*http.Response, error) {
 		return nil, err
 	}
 	return resp, nil
-}
-
-func bodyToString(body io.ReadCloser) (string, error) {
-	defer body.Close()
-	payload, err := ioutil.ReadAll(body)
-	if err != nil {
-		return "", err
-	}
-
-	return string(payload), nil
 }
 
 func duplicate(request *http.Request) (request1 *http.Request, request2 *http.Request) {

--- a/src/server/main.go
+++ b/src/server/main.go
@@ -73,32 +73,19 @@ func (s *Server) handle(w http.ResponseWriter, req *http.Request) {
 
 	var reqRef, reqExp = duplicate(req)
 
-	resp, err := sendFurther(reqRef, s.reference)
-	if err != nil {
-		log.Fatal(err)
-	}
-	payloadRef, err := bodyToString(resp.Body)
+	respA, err := sendFurther(reqRef, s.reference)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	resp, err = sendFurther(reqExp, s.experiment)
-	if err != nil {
-		log.Fatal(err)
-	}
-	payloadExp, err := bodyToString(resp.Body)
+	respB, err := sendFurther(reqExp, s.experiment)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	if payloadRef != payloadExp {
-		w.Header().Set("X-web-scientist-type", "reference")
-		fmt.Fprintf(w, payloadRef)
-	} else {
-		w.Header().Set("X-web-scientist-type", "experiment")
-		fmt.Fprintf(w, payloadExp)
+	JL := jlog.New()
 
-	}
+	fmt.Println(JL.CompareResponses(respA, respB))
 
 }
 

--- a/src/server/main.go
+++ b/src/server/main.go
@@ -84,8 +84,8 @@ func (s *Server) handle(w http.ResponseWriter, req *http.Request) {
 	}
 
 	JL := jlog.New()
-
-	fmt.Println(JL.CompareResponses(respA, respB))
+	out, _ := JL.CompareResponses(respA, respB)
+	ioutil.WriteFile("log.json", out, 0755)
 
 }
 


### PR DESCRIPTION
Es wird immer noch die log.json Datei vor dem Response an den Client geschrieben, obwohl die Funkton für die Response als erste Aufgerufen wird.

Closes #4 